### PR TITLE
Added add and remove restaurants from plan functionality

### DIFF
--- a/FastFoodFinder/Restaurant.h
+++ b/FastFoodFinder/Restaurant.h
@@ -3,6 +3,7 @@
 #include <algorithm>
 #include <fstream>
 #include <vector>
+#include <queue>
 #include <sstream>
 #include <QString>
 #include <string>

--- a/FastFoodFinder/main.cpp
+++ b/FastFoodFinder/main.cpp
@@ -16,6 +16,7 @@ int main(int argc, char *argv[])
     //Declare a main window
     MainWindow w;
 
+
     //Pass the main window to the login screen class
     Login log(&w);
 

--- a/FastFoodFinder/mainwindow.hpp
+++ b/FastFoodFinder/mainwindow.hpp
@@ -1,6 +1,6 @@
 #pragma once
 #include "accountType.hpp"
-#include<QMainWindow>
+#include <QMainWindow>
 #include <QMessageBox>
 #include <QListWidget>
 #include <QFileDialog>
@@ -31,7 +31,9 @@ class MainWindow : public QMainWindow
         void on_ListButton_clicked();
         void on_PlanTripButton_clicked();
         void on_AddRestButton_clicked();
+        void on_AddRestPlanButton_clicked();
         void on_removeRestaurantButton_clicked();
+        void on_removeRestaurantPlanButton_clicked();
         void on_confirmButton_clicked();
         void on_cancelButton_clicked();
         void on_ViewPlansButton_clicked();

--- a/FastFoodFinder/mainwindow.ui
+++ b/FastFoodFinder/mainwindow.ui
@@ -448,7 +448,7 @@
      <number>2</number>
     </property>
     <property name="currentIndex">
-     <number>6</number>
+     <number>2</number>
     </property>
     <widget class="QWidget" name="homePage">
      <widget class="QLabel" name="home_label">
@@ -512,7 +512,7 @@
        <rect>
         <x>10</x>
         <y>40</y>
-        <width>201</width>
+        <width>151</width>
         <height>271</height>
        </rect>
       </property>
@@ -520,9 +520,9 @@
      <widget class="QListWidget" name="restaurantInPlan_listWidget">
       <property name="geometry">
        <rect>
-        <x>250</x>
+        <x>170</x>
         <y>40</y>
-        <width>211</width>
+        <width>141</width>
         <height>271</height>
        </rect>
       </property>
@@ -532,7 +532,7 @@
        <rect>
         <x>10</x>
         <y>10</y>
-        <width>181</width>
+        <width>121</width>
         <height>21</height>
        </rect>
       </property>
@@ -543,9 +543,9 @@
      <widget class="QLabel" name="label_2">
       <property name="geometry">
        <rect>
-        <x>250</x>
+        <x>170</x>
         <y>10</y>
-        <width>181</width>
+        <width>91</width>
         <height>21</height>
        </rect>
       </property>
@@ -592,6 +592,29 @@ From Plan</string>
       </property>
       <property name="text">
        <string>Edit Menu</string>
+      </property>
+     </widget>
+     <widget class="QListWidget" name="menuItemsInPlan_listWidget">
+      <property name="geometry">
+       <rect>
+        <x>320</x>
+        <y>40</y>
+        <width>151</width>
+        <height>271</height>
+       </rect>
+      </property>
+     </widget>
+     <widget class="QLabel" name="label_4">
+      <property name="geometry">
+       <rect>
+        <x>320</x>
+        <y>10</y>
+        <width>141</width>
+        <height>21</height>
+       </rect>
+      </property>
+      <property name="text">
+       <string>Menu Items</string>
       </property>
      </widget>
     </widget>

--- a/FastFoodFinder/plan.cpp
+++ b/FastFoodFinder/plan.cpp
@@ -2,5 +2,7 @@
 
 Plan::Plan()
 {
+    list<Restaurant> list;
+
 
 }

--- a/FastFoodFinder/plan.h
+++ b/FastFoodFinder/plan.h
@@ -1,6 +1,6 @@
 #ifndef PLAN_H
 #define PLAN_H
-#include "Restaurant.h"
+#include "mainwindow.hpp"
 
 
 class Plan
@@ -9,7 +9,9 @@ public:
     Plan();
 
 private:
-    vector<Restaurant> plan;
+    queue<Restaurant> plan;
+    double totalDistance;
+    double totalRevenue;
 };
 
 #endif // PLAN_H


### PR DESCRIPTION
Hey guys, so here's the UI for the add and remove restaurants. Commented and all. I haven't implemented Anna's new restaurant stuff yet. But adding and removing restaurants from the plan should work as intended and admin interference will not crash anything. Adding extra restaurants updates the available restaurants. Removing any restaurant that exists in the 'restaurants in plan' page will delete the desired restaurant and return any other restaurants back to the 'available restaurants' page. 